### PR TITLE
TabBar item tap animation

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SwipeableTabBarController/Classes/SwipeAnimationType.swift
+++ b/SwipeableTabBarController/Classes/SwipeAnimationType.swift
@@ -23,6 +23,7 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
     case overlap
     case sideBySide
     case push
+    case none
 
     
     /// Setup the views hirearchy for different animations types.
@@ -61,6 +62,8 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
             let scaledWidth = screenWidth/6
             to?.frame.origin.x = direction ? -scaledWidth : scaledWidth
             from?.frame.origin.x = 0
+        case .none:
+            break
         }
     }
 
@@ -82,6 +85,8 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
         case .push:
             to?.frame.origin.x = 0
             from?.frame.origin.x = direction ? screenWidth : -screenWidth
+        case .none:
+            break
         }
     }
 }

--- a/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
+++ b/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
@@ -16,14 +16,16 @@ open class SwipeableTabBarController: UITabBarController {
     // MARK: - Private API
     fileprivate var swipeInteractor: SwipeInteractor!
     fileprivate var swipeAnimatedTransitioning: SwipeTransitioningProtocol!
-    fileprivate var animationEnabled: Bool = true
+    fileprivate var tapAnimatedTransitioning: SwipeTransitioningProtocol!
+    fileprivate var currentAnimatedTransitioningType: SwipeTransitioningProtocol!
+
     private let kSelectedViewControllerKey = "selectedViewController"
 
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setup()
     }
-    
+
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         setup()
@@ -37,8 +39,11 @@ open class SwipeableTabBarController: UITabBarController {
                 self.selectedViewController = controllers[self.selectedIndex]
             }
         }
+
         // Set the animation to excecute with swipe percentage
         swipeAnimatedTransitioning = SwipeAnimation()
+        tapAnimatedTransitioning = swipeAnimatedTransitioning
+        currentAnimatedTransitioningType = swipeAnimatedTransitioning
 
         // UITabBarControllerDelegate for transitions.
         delegate = self
@@ -46,11 +51,11 @@ open class SwipeableTabBarController: UITabBarController {
         // Observe selected index changes to wire the gesture recognizer to the viewController.
         addObserver(self, forKeyPath: kSelectedViewControllerKey, options: .new, context: nil)
     }
-    
+
     // MARK: - Public API
-    
+
     override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        
+
         // .selectedViewController changes so we setup the swipe interactor to the new selected Controller.
         if keyPath == kSelectedViewControllerKey {
             if let selectedController = selectedViewController {
@@ -67,15 +72,23 @@ open class SwipeableTabBarController: UITabBarController {
         swipeAnimatedTransitioning.animationType = type
     }
 
+    /// Modify the swipe animation, it can be one of the default `SwipeAnimationType` or your own type
+    /// conforming to `SwipeAnimationTypeProtocol`.
+    ///
+    /// - Parameter type: object conforming to `SwipeAnimationTypeProtocol`.
+    open func setTapAnimation(type: SwipeAnimationTypeProtocol) {
+        tapAnimatedTransitioning = SwipeAnimation(animationType: type)
+    }
+
     /// Modify the transitioning animation.
     ///
-    /// - Parameter animation: UIViewControllerAnimatedTransitioning conforming to 
+    /// - Parameter animation: UIViewControllerAnimatedTransitioning conforming to
     /// `SwipeTransitioningProtocol`.
     open func setAnimationTransitioning(animation: SwipeTransitioningProtocol) {
         swipeAnimatedTransitioning = animation
     }
 
-    /// Toggle the diagonal swipe to remove the just `perfect` horizontal swipe interaction 
+    /// Toggle the diagonal swipe to remove the just `perfect` horizontal swipe interaction
     /// needed to perform the transition.
     ///
     /// - Parameter enabled: Bool value to the corresponding diagnoal swipe support.
@@ -83,12 +96,6 @@ open class SwipeableTabBarController: UITabBarController {
         swipeInteractor.isDiagonalSwipeEnabled = enabled
     }
 
-    /// Toggles the transition animation
-    ///
-    /// - Parameter enabled: Bool value to set if it should animate the transition
-    open func setAnimation(enabled: Bool) {
-        animationEnabled = enabled
-    }
     /// Enables/Disables swipes on the tabbar controller.
     open var isSwipeEnabled = true {
         didSet { swipeInteractor.isEnabled = isSwipeEnabled }
@@ -97,23 +104,30 @@ open class SwipeableTabBarController: UITabBarController {
 
 // MARK: - UITabBarControllerDelegate
 extension SwipeableTabBarController: UITabBarControllerDelegate {
-    
+
     public func tabBarController(_ tabBarController: UITabBarController, animationControllerForTransitionFrom fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
 
-        // Checks if the animation is enabled and if not returns the new controller instantly.
-        guard animationEnabled else { return nil }
-        
-        // Get the indexes of the ViewControllers involved in the animation to determine the animation flow. 
+        // Get the indexes of the ViewControllers involved in the animation to determine the animation flow.
         guard let fromVCIndex = tabBarController.viewControllers?.index(of: fromVC),
-              let toVCIndex   = tabBarController.viewControllers?.index(of: toVC) else {
+            let toVCIndex   = tabBarController.viewControllers?.index(of: toVC) else {
                 return nil
         }
 
-        swipeAnimatedTransitioning.fromLeft = fromVCIndex > toVCIndex
-        return swipeAnimatedTransitioning
+        currentAnimatedTransitioningType.fromLeft = fromVCIndex > toVCIndex
+        return currentAnimatedTransitioningType
     }
-    
+
     public func tabBarController(_ tabBarController: UITabBarController, interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return swipeInteractor.interactionInProgress ? swipeInteractor : nil
+    }
+
+    public func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        currentAnimatedTransitioningType = swipeAnimatedTransitioning
+    }
+
+    public func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        currentAnimatedTransitioningType = tapAnimatedTransitioning
+        
+        return true
     }
 }


### PR DESCRIPTION
Added option to specify animation for tap on tabBar item. Preserved default behaviour in which tap animation is same as swipe animation. To set different tap animation call `setTapAnimation(type:)`.

Added `SwipeAnimationType.none` which does not perform animation.