### PR TITLE
added import UIKit

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
@@ -6,6 +6,8 @@
 //
 //
 
+import UIKit
+
 /// Added to support custom `UIViewControllerAnimatedTransitioning` in different applications.
 public protocol SwipeTransitioningProtocol: UIViewControllerAnimatedTransitioning {
     


### PR DESCRIPTION
When importing the project manually, this was needed to compile as `UIViewControllerAnimatedTransitioning` wasn't recognized without it