### PR TITLE
Transition state checks

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeAnimation.swift
+++ b/SwipeableTabBarController/Classes/SwipeAnimation.swift
@@ -14,17 +14,13 @@ import UIKit
 class SwipeAnimation: NSObject, SwipeTransitioningProtocol {
 
     /// Duration of the transition animation.
-    fileprivate var animationDuration: TimeInterval!
+    fileprivate var animationDuration: TimeInterval
 
-    /// Is currently performing an animation
-    fileprivate var animationStarted = false
-    
     // TODO: - (marcosgriselli) add support for snapshot views.
-    /// Side which de animation will be performed from.
+    // MARK: - SwipeTransitioningProtocol
     var fromLeft = false
-
-    /// Swipe animation type to perform animation
     var animationType: SwipeAnimationTypeProtocol = SwipeAnimationType.sideBySide
+    var transitionStarted = false
 
     /// Init with injectable parameters
     ///
@@ -33,9 +29,9 @@ class SwipeAnimation: NSObject, SwipeTransitioningProtocol {
     ///   - animationType: animation type to perform while transitioning
     init(animationDuration: TimeInterval = 0.33,
          animationType: SwipeAnimationTypeProtocol = SwipeAnimationType.sideBySide) {
-        super.init()
         self.animationDuration = animationDuration
         self.animationType = animationType
+        super.init()
     }
 
     // MARK: - UIViewControllerAnimatedTransitioning
@@ -47,7 +43,7 @@ class SwipeAnimation: NSObject, SwipeTransitioningProtocol {
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         
         // Pre check if there's a previous transition runing and cancel the current one.
-        if animationStarted {
+        if transitionStarted {
             return transitionContext.completeTransition(false)
         }
 
@@ -58,7 +54,7 @@ class SwipeAnimation: NSObject, SwipeTransitioningProtocol {
                 return transitionContext.completeTransition(false)
         }
         
-        animationStarted = true
+        transitionStarted = true
         
         let duration = transitionDuration(using: transitionContext)
         fromView.endEditing(true)
@@ -90,10 +86,16 @@ class SwipeAnimation: NSObject, SwipeTransitioningProtocol {
                                     toView: UIView?,
                                     in context: UIViewControllerContextTransitioning) {
         DispatchQueue.main.async {
-            self.animationStarted = false
+            self.transitionStarted = false
             if context.transitionWasCancelled {
+                self.animationType.animation(fromView: toView,
+                                             toView: fromView,
+                                             direction: self.fromLeft)
                 toView?.removeFromSuperview()
             } else {
+                self.animationType.animation(fromView: fromView,
+                                             toView: toView,
+                                             direction: self.fromLeft)
                 fromView?.removeFromSuperview()
             }
             context.completeTransition(!context.transitionWasCancelled)

--- a/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
@@ -10,10 +10,13 @@ import UIKit
 
 /// Added to support custom `UIViewControllerAnimatedTransitioning` in different applications.
 public protocol SwipeTransitioningProtocol: UIViewControllerAnimatedTransitioning {
-    
+
     /// Direction in which the animation will occur.
     var fromLeft: Bool { get set }
 
     /// Animation type used.
     var animationType: SwipeAnimationTypeProtocol { get set }
+
+    /// Indicates if the transition has started.
+    var transitionStarted: Bool { get set }
 }

--- a/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
+++ b/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
@@ -46,6 +46,11 @@ open class SwipeableTabBarController: UITabBarController {
         addObserver(self, forKeyPath: kSelectedViewControllerKey, options: .new, context: nil)
     }
 
+    /// Checks if a transition is being performed.
+    private var isTransitioning: Bool {
+        return swipeAnimatedTransitioning.transitionStarted || tapAnimatedTransitioning.transitionStarted
+    }
+
     // MARK: - Public API
 
     override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -120,6 +125,10 @@ extension SwipeableTabBarController: UITabBarControllerDelegate {
     }
 
     public func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        // Transitioning or interacting.
+        if isTransitioning || swipeInteractor.interactionInProgress {
+            return false
+        }
         currentAnimatedTransitioningType = tapAnimatedTransitioning
         return true
     }


### PR DESCRIPTION
In order to avoid launching a new transition when a previous one is running I added a few checks to make sure we never get that odd behavior from two transitions running simultaneously. 