### PR TITLE
Fix: Avoid starting a new transition if a transitionCoordinator is present

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
+++ b/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
@@ -148,4 +148,8 @@ extension SwipeableTabBarController: UITabBarControllerDelegate {
             return nil
         }
     }
+    
+    open func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        return transitionCoordinator == nil 
+    }
 }


### PR DESCRIPTION
Adds `tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool` `UITabBarControllerDelegate` method to check if a transition is going on when tapping a tab item. 

Fixes #67 