### PR TITLE
Allow setting the tap animation duration

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
@@ -11,15 +11,13 @@ import UIKit
 /// Swipe animation conforming to `UIViewControllerAnimatedTransitioning`
 /// Can be replaced by any other class confirming to `UIViewControllerTransitioning`
 /// on your `SwipeableTabBarController` subclass.
-@objc(SwipeTransitionAnimator) public
+@objc(SwipeTransitionAnimator)
 class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
 
-    /// Duration of the transition animation.
-    public var animationDuration: TimeInterval
-
     // MARK: - SwipeTransitioningProtocol
-    public var targetEdge: UIRectEdge
-    public var animationType: SwipeAnimationTypeProtocol = SwipeAnimationType.sideBySide
+    var animationDuration: TimeInterval
+    var targetEdge: UIRectEdge
+    var animationType: SwipeAnimationTypeProtocol = SwipeAnimationType.sideBySide
 
     /// Init with injectable parameters
     ///
@@ -37,11 +35,11 @@ class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
 
     // MARK: - UIViewControllerAnimatedTransitioning
     
-    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return (transitionContext?.isAnimated == true) ? animationDuration : 0
     }
     
-    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let containerView = transitionContext.containerView
         //swiftlint:disable force_unwrapping
         let fromView = transitionContext.view(forKey: UITransitionContextViewKey.from)!

--- a/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitionAnimator.swift
@@ -11,15 +11,15 @@ import UIKit
 /// Swipe animation conforming to `UIViewControllerAnimatedTransitioning`
 /// Can be replaced by any other class confirming to `UIViewControllerTransitioning`
 /// on your `SwipeableTabBarController` subclass.
-@objc(SwipeTransitionAnimator)
+@objc(SwipeTransitionAnimator) public
 class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
 
     /// Duration of the transition animation.
-    private var animationDuration: TimeInterval
+    public var animationDuration: TimeInterval
 
     // MARK: - SwipeTransitioningProtocol
-    var targetEdge: UIRectEdge
-    var animationType: SwipeAnimationTypeProtocol = SwipeAnimationType.sideBySide
+    public var targetEdge: UIRectEdge
+    public var animationType: SwipeAnimationTypeProtocol = SwipeAnimationType.sideBySide
 
     /// Init with injectable parameters
     ///
@@ -37,11 +37,11 @@ class SwipeTransitionAnimator: NSObject, SwipeTransitioningProtocol {
 
     // MARK: - UIViewControllerAnimatedTransitioning
     
-    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return (transitionContext?.isAnimated == true) ? animationDuration : 0
     }
     
-    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let containerView = transitionContext.containerView
         //swiftlint:disable force_unwrapping
         let fromView = transitionContext.view(forKey: UITransitionContextViewKey.from)!

--- a/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
+++ b/SwipeableTabBarController/Classes/SwipeTransitioningProtocol.swift
@@ -13,6 +13,9 @@ import UIKit
 /// Added to support custom `UIViewControllerAnimatedTransitioning` in different applications.
 public protocol SwipeTransitioningProtocol: UIViewControllerAnimatedTransitioning {
 
+    /// Duration of the transition animation.
+    var animationDuration: TimeInterval { get set }
+
     /// Direction in which the animation will occur.
     var targetEdge: UIRectEdge { get set }
 


### PR DESCRIPTION
Make the `SwipeTransitionAnimator` public and allow setting the `animationDuration` property. This way subclasses of `SwipeableTabBarController` can tweak the duration like this:

```swift
override
func tabBarController(
    _ tabBarController: UITabBarController,
    animationControllerForTransitionFrom fromVC: UIViewController,
    to toVC: UIViewController
) -> UIViewControllerAnimatedTransitioning? {
    let transitioning = super.tabBarController(
        tabBarController,
        animationControllerForTransitionFrom: fromVC, to: toVC
    )
   
    guard let animator = transitioning as? SwipeTransitionAnimator else {
        return transitioning
    }
    
    animator.animationDuration = 0.2
    return transitioning
}
```

Fixes #72.
