### PR TITLE
Prevent other gesture recognizers from overriding the tap animation

### DIFF
--- a/Example/SwipeableTabBarController/TabBarController.swift
+++ b/Example/SwipeableTabBarController/TabBarController.swift
@@ -26,8 +26,8 @@ class TabBarController: SwipeableTabBarController {
         /// if you want cycling switch tab, set true 'isCyclingEnabled'
         isCyclingEnabled = true
 
-        /// Disable custom transition on tap.
-        //tapAnimatedTransitioning = nil
+        /// Disable custom transition for tap.
+        tapAnimatedTransitioning?.animationDuration = 0
         
         /// Set swipe to only work when strictly horizontal.
 //        diagonalSwipeEnabled = true

--- a/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
+++ b/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
@@ -80,7 +80,7 @@ open class SwipeableTabBarController: UITabBarController {
     }
 
     @IBAction func panGestureRecognizerDidPan(_ sender: UIPanGestureRecognizer) {
-        if sender.state == .ended {
+        if sender.state == .ended || sender.state == .cancelled {
             currentAnimatedTransitioningType = tapAnimatedTransitioning
         }
         // Do not attempt to begin an interactive transition if one is already


### PR DESCRIPTION
Fixes #90

##### Checklist

- [ ] Includes UI tests
- [ ] Readme is updated

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description

This pull requests fixes an issue caused by having other gesture recognizers in the app that can cause the pan gesture of the tab bar to fail and never get in `.ended` state. This would lead to the tap animation to be overridden by the swipe animation by mistake. It is especially a problem for those like me who want the tap animation to be disabled.

The PR also updates the example app to show that it's possible to disable the tap animation by setting its duration to 0.
