### PR TITLE
Public transitioning properties

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
+++ b/SwipeableTabBarController/Classes/SwipeableTabBarController.swift
@@ -15,10 +15,14 @@ import UIKit
 open class SwipeableTabBarController: UITabBarController {
 
     /// Animated transition to be performed while swiping
-    private(set) public var swipeAnimatedTransitioning: SwipeTransitioningProtocol? = SwipeTransitionAnimator()
+    public var swipeAnimatedTransitioning: SwipeTransitioningProtocol? = SwipeTransitionAnimator()
     
     /// Animated transition to be performed when tapping on a tabbar item
-    private(set) public var tapAnimatedTransitioning: SwipeTransitioningProtocol? = SwipeTransitionAnimator()
+    public var tapAnimatedTransitioning: SwipeTransitioningProtocol? = SwipeTransitionAnimator() {
+        didSet {
+            currentAnimatedTransitioningType = tapAnimatedTransitioning
+        }
+    }
     
     /// Animated transition being used currently
     private var currentAnimatedTransitioningType: SwipeTransitioningProtocol?
@@ -73,14 +77,13 @@ open class SwipeableTabBarController: UITabBarController {
     private func setup() {
         // UITabBarControllerDelegate for transitions.
         delegate = self
-        currentAnimatedTransitioningType = tapAnimatedTransitioning
         // Gesture setup
         panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(panGestureRecognizerDidPan(_:)))
         view.addGestureRecognizer(panGestureRecognizer)
     }
 
     @IBAction func panGestureRecognizerDidPan(_ sender: UIPanGestureRecognizer) {
-        if sender.state == .ended {
+        if sender.state == .ended || sender.state == .cancelled {
             currentAnimatedTransitioningType = tapAnimatedTransitioning
         }
         // Do not attempt to begin an interactive transition if one is already


### PR DESCRIPTION
This PR restores public access to `tapAnimatedTransitioning` and `swipeAnimatedTransitioning` so we can set them to `nil` if we don't want animations. It also includes a gesture state check from #91. 