### PR TITLE
Fix transitions for apps in split view / slide over

### DIFF
--- a/SwipeableTabBarController/Classes/SwipeAnimationType.swift
+++ b/SwipeableTabBarController/Classes/SwipeAnimationType.swift
@@ -48,7 +48,7 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
     ///   - to: New selected tab view.
     ///   - direction: Direction in which the views will animate.
     public func prepare(fromView from: UIView, toView to: UIView, direction: Bool) {
-        let screenWidth = UIScreen.main.bounds.size.width
+        let screenWidth = from.frame.size.width
         switch self {
         case .overlap:
             to.frame.origin.x = direction ? -screenWidth : screenWidth
@@ -69,7 +69,7 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
     ///   - to: New selected tab view.
     ///   - direction: Direction in which the views will animate.
     public func animation(fromView from: UIView, toView to: UIView, direction: Bool) {
-        let screenWidth = UIScreen.main.bounds.size.width
+        let screenWidth = from.frame.size.width
         switch self {
         case .overlap:
             to.frame.origin.x = 0


### PR DESCRIPTION
This PR fixes a problem affecting apps that support Split View / Slide Over on iPad.
In fact in these instances, any swipe transition would show temporary black voids in-between app screens as explained [here](https://github.com/marcosgriselli/SwipeableTabBarController/issues/98#issuecomment-735226321).
In general, the fix solves transitions for any case where the width of the app is not the same as the size of the device.

