### PR TITLE
Feature/Swipe directions

### DIFF
--- a/Sources/SwipeableTabBarController.swift
+++ b/Sources/SwipeableTabBarController.swift
@@ -29,7 +29,7 @@ open class SwipeableTabBarController: UITabBarController {
     
     /// Pan gesture for the swiping interaction
     //swiftlint:disable next implicitly_unwrapped_optional
-    private var panGestureRecognizer: UIPanGestureRecognizer!
+    private var panGestureRecognizer: UIPanGestureRecognizer?
 
     @available(*, deprecated, message: "For the moment the diagonal swipe configuration is not available.")
     /// Toggle the diagonal swipe to remove the just `perfect` horizontal swipe interaction
@@ -38,7 +38,7 @@ open class SwipeableTabBarController: UITabBarController {
 
     /// Enables/Disables swipes on the tabbar controller.
     open var isSwipeEnabled = true {
-        didSet { panGestureRecognizer.isEnabled = isSwipeEnabled }
+        didSet { panGestureRecognizer?.isEnabled = isSwipeEnabled }
     }
 
     /// Enables/Disables cycling swipes on the tabBar controller. default value is 'false'
@@ -50,7 +50,7 @@ open class SwipeableTabBarController: UITabBarController {
             guard panGestureRecognizer != nil else {
                 return
             }
-            panGestureRecognizer.minimumNumberOfTouches = minimumNumberOfTouches
+            panGestureRecognizer?.minimumNumberOfTouches = minimumNumberOfTouches
         }
     }
     
@@ -60,7 +60,7 @@ open class SwipeableTabBarController: UITabBarController {
             guard panGestureRecognizer != nil else {
                 return
             }
-            panGestureRecognizer.maximumNumberOfTouches = maximumNumberOfTouches
+            panGestureRecognizer?.maximumNumberOfTouches = maximumNumberOfTouches
         }
     }
     
@@ -90,8 +90,9 @@ open class SwipeableTabBarController: UITabBarController {
         // UITabBarControllerDelegate for transitions.
         delegate = self
         // Gesture setup
-        panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(panGestureRecognizerDidPan(_:)))
-        view.addGestureRecognizer(panGestureRecognizer)
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(panGestureRecognizerDidPan(_:)))
+        view.addGestureRecognizer(panGesture)
+        panGestureRecognizer = panGesture
     }
 
     @IBAction func panGestureRecognizerDidPan(_ sender: UIPanGestureRecognizer) {
@@ -173,8 +174,9 @@ extension SwipeableTabBarController: UITabBarControllerDelegate {
     }
 
     open func tabBarController(_ tabBarController: UITabBarController, interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        if panGestureRecognizer.state == .began || panGestureRecognizer.state == .changed {
-            return SwipeInteractor(gestureRecognizer: panGestureRecognizer, edge: currentAnimatedTransitioningType?.targetEdge ?? .right)
+        guard let panGesture = panGestureRecognizer else { return nil }
+        if panGesture.state == .began || panGesture.state == .changed {
+            return SwipeInteractor(gestureRecognizer: panGesture, edge: currentAnimatedTransitioningType?.targetEdge ?? .right)
         } else {
             return nil
         }

--- a/Sources/SwipeableTabBarController.swift
+++ b/Sources/SwipeableTabBarController.swift
@@ -41,6 +41,9 @@ open class SwipeableTabBarController: UITabBarController {
         didSet { panGestureRecognizer?.isEnabled = isSwipeEnabled }
     }
 
+    /// Allowed swipe directions. Only applied if `isSwipeEnabled` equals `true`.
+    open var allowedSwipeDirection: AllowedSwipeDirection = .both
+
     /// Enables/Disables cycling swipes on the tabBar controller. default value is 'false'
     open var isCyclingEnabled = false
     
@@ -91,6 +94,7 @@ open class SwipeableTabBarController: UITabBarController {
         delegate = self
         // Gesture setup
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(panGestureRecognizerDidPan(_:)))
+        panGesture.delegate = self
         view.addGestureRecognizer(panGesture)
         panGestureRecognizer = panGesture
     }
@@ -147,6 +151,29 @@ open class SwipeableTabBarController: UITabBarController {
             if context.isCancelled && sender.state == .changed {
                 self.beginInteractiveTransitionIfPossible(sender)
             }
+        }
+    }
+}
+
+extension SwipeableTabBarController {
+    public enum AllowedSwipeDirection {
+        case left
+        case right
+        case both
+    }
+}
+
+extension SwipeableTabBarController: UIGestureRecognizerDelegate {
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let panGesture = gestureRecognizer as? UIPanGestureRecognizer, isSwipeEnabled else { return true }
+        let translation = panGesture.translation(in: view)
+        switch allowedSwipeDirection {
+        case .left:
+            return translation.x > 0
+        case .right:
+            return translation.x > 0
+        case .both:
+            return true
         }
     }
 }


### PR DESCRIPTION
A new flag `allowedSwipeDirection` is added to the instance. The purpose of this flag is to control in which direction (left/right) the user can swipe between tabs.

If you set the value to `left`, the user will not be able to swipe to the next tab.
If you set the value to `right`, the user will not be able to swipe to the previous tab.
The default value is `both` which means left and right.

You would usually apply some swipe limitation only to a particular tab. In that case, you need to update this value whenever the tab changes.
