### PR TITLE
Fix transition views adding order for `.sideBySide` transitions

### DIFF
--- a/Sources/SwipeAnimationType.swift
+++ b/Sources/SwipeAnimationType.swift
@@ -34,7 +34,7 @@ public enum SwipeAnimationType: SwipeAnimationTypeProtocol {
     ///   - toView: New selected tab view.
     public func addTo(containerView: UIView, fromView: UIView, toView: UIView) {
         switch self {
-        case .push:
+        case .push, .sideBySide:
             containerView.insertSubview(toView, belowSubview: fromView)
         default:
             containerView.addSubview(toView)


### PR DESCRIPTION
This PR fixes a bug where the `toView` would be displayed at the top of the stack for an instant before starting a transition.

Fixes #104 