### PR TITLE
Serialize tab selections during active transitions

### DIFF
--- a/Example/TabBarController.swift
+++ b/Example/TabBarController.swift
@@ -31,9 +31,41 @@ class TabBarController: SwipeableTabBarController {
         
         /// Set swipe to only work when strictly horizontal.
 //        diagonalSwipeEnabled = true
+
+        if ProcessInfo.processInfo.arguments.contains("StressSelectedIndexTransitions") {
+            stressSelectedIndexTransitions(usingSelectedViewController: false)
+        }
+
+        if ProcessInfo.processInfo.arguments.contains("StressSelectedViewControllerTransitions") {
+            stressSelectedIndexTransitions(usingSelectedViewController: true)
+        }
     }
     
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         // Handle didSelect viewController method here
+    }
+
+    private func stressSelectedIndexTransitions(usingSelectedViewController: Bool) {
+        var transitionCount = 0
+
+        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] timer in
+            guard let self = self else {
+                timer.invalidate()
+                return
+            }
+
+            guard transitionCount < 10 else {
+                timer.invalidate()
+                return
+            }
+
+            let nextIndex = abs(self.selectedIndex - 1)
+            if usingSelectedViewController, let viewController = self.viewControllers?[nextIndex] {
+                self.selectedViewController = viewController
+            } else {
+                self.selectedIndex = nextIndex
+            }
+            transitionCount += 1
+        }
     }
 }

--- a/ExampleUITests/SwipeableTabBarControllerUITests.swift
+++ b/ExampleUITests/SwipeableTabBarControllerUITests.swift
@@ -34,6 +34,14 @@ class SwipeableTabBarControllerUITests: XCTestCase {
         
     }
 
+    private func assertTabSelected(_ tab: Tab, in app: XCUIApplication, file: StaticString = #file, line: UInt = #line) {
+        let tabBar = app.tabBars.firstMatch
+        let navigationBar = app.navigationBars[tab.navBarTitle]
+        XCTAssert(navigationBar.waitForExistence(timeout: 2), file: file, line: line)
+        XCTAssert(navigationBar.isHittable, file: file, line: line)
+        XCTAssert(tabBar.buttons.allElementsBoundByIndex[tab.index].isSelected, file: file, line: line)
+    }
+
     /// Tests navigation with swiping and tapping.
     func testTabBarInteractions() {
         let app = XCUIApplication()
@@ -47,31 +55,54 @@ class SwipeableTabBarControllerUITests: XCTestCase {
         /// Assert that the tabBarItem is selected and that the new view controller
         /// exists and its ready to interact with.
         /// This is a simple test but it will be useful for unexpected states.
-        let assertTabSelected: (Tab) -> Void = { tab in
-            XCTAssert(tabBar.buttons.allElementsBoundByIndex[tab.index].isSelected)
-            let navigationBar = app.navigationBars[tab.navBarTitle]
-            XCTAssert(navigationBar.exists)
-            XCTAssert(navigationBar.isHittable)
-        }
         app.swipeRight()
-        assertTabSelected(.comments)
+        assertTabSelected(.comments, in: app)
         app.swipeLeft()
-        assertTabSelected(.team)
+        assertTabSelected(.team, in: app)
         app.swipeLeft()
-        assertTabSelected(.settings)
+        assertTabSelected(.settings, in: app)
         app.tabBars.buttons.element(boundBy: 0).tap()
-        assertTabSelected(.comments)
+        assertTabSelected(.comments, in: app)
         app.tabBars.buttons.element(boundBy: 1).tap()
-        assertTabSelected(.team)
+        assertTabSelected(.team, in: app)
         app.tabBars.buttons.element(boundBy: 2).tap()
-        assertTabSelected(.settings)
+        assertTabSelected(.settings, in: app)
 
         // Tests Cycling tabBar
         app.swipeLeft()
-        assertTabSelected(.comments)
+        assertTabSelected(.comments, in: app)
         app.swipeRight()
-        assertTabSelected(.settings)
+        assertTabSelected(.settings, in: app)
         app.swipeRight()
-        assertTabSelected(.team)
+        assertTabSelected(.team, in: app)
+    }
+
+    func testRapidSelectedIndexTransitionsRemainInteractive() {
+        assertRapidProgrammaticTransitionsRemainInteractive("StressSelectedIndexTransitions")
+    }
+
+    func testRapidSelectedViewControllerTransitionsRemainInteractive() {
+        assertRapidProgrammaticTransitionsRemainInteractive("StressSelectedViewControllerTransitions")
+    }
+
+    private func assertRapidProgrammaticTransitionsRemainInteractive(_ launchArgument: String) {
+        let app = XCUIApplication()
+        app.launchArguments = [launchArgument]
+        app.launch()
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 4))
+        XCTAssertEqual(tabBar.buttons.allElementsBoundByIndex.count, 3, "Unexpected number of view controllers on the TabBar. Please update tests to reflect these changes.")
+
+        Thread.sleep(forTimeInterval: 2)
+
+        app.tabBars.buttons.element(boundBy: Tab.settings.index).tap()
+        assertTabSelected(.settings, in: app)
+
+        app.tabBars.buttons.element(boundBy: Tab.comments.index).tap()
+        assertTabSelected(.comments, in: app)
+
+        app.swipeLeft()
+        assertTabSelected(.team, in: app)
     }
 }

--- a/SwipeableTabBarController/SwipeableTabBarController.swift
+++ b/SwipeableTabBarController/SwipeableTabBarController.swift
@@ -14,6 +14,16 @@ import UIKit
 @objc(SwipeableTabBarController)
 open class SwipeableTabBarController: UITabBarController {
 
+    private enum PendingSelection {
+        case index(Int, SelectionSource)
+        case viewController(UIViewController, SelectionSource)
+    }
+
+    private enum SelectionSource {
+        case swipe
+        case tap
+    }
+
     /// Animated transition to be performed while swiping
     public var swipeAnimatedTransitioning: SwipeTransitioningProtocol? = SwipeTransitionAnimator()
     
@@ -26,6 +36,18 @@ open class SwipeableTabBarController: UITabBarController {
     
     /// Animated transition being used currently
     private var currentAnimatedTransitioningType: SwipeTransitioningProtocol?
+
+    /// Latest selection requested while UIKit is still completing a tab transition.
+    private var pendingSelection: PendingSelection?
+
+    /// Prevents registering multiple completion handlers for the same pending selection.
+    private var isPendingSelectionHandlerScheduled = false
+
+    /// Tracks whether the current pan gesture already started an interactive transition.
+    private var isSwipeGestureDrivingTransition = false
+
+    /// Indicates that UIKit should wire the next transition to the pan interactor.
+    private var shouldUsePanInteractorForCurrentTransition = false
     
     /// Pan gesture for the swiping interaction
     //swiftlint:disable next implicitly_unwrapped_optional
@@ -71,10 +93,24 @@ open class SwipeableTabBarController: UITabBarController {
     open override var selectedIndex: Int {
         get { return super.selectedIndex }
         set {
-            if transitionCoordinator != nil {
-                [swipeAnimatedTransitioning, tapAnimatedTransitioning].forEach { $0?.forceTransitionToFinish() }
+            selectIndex(newValue)
+        }
+    }
+
+    /// Override selectedViewController for programmatic changes.
+    open override var selectedViewController: UIViewController? {
+        get { return super.selectedViewController }
+        set {
+            guard let viewController = newValue,
+                containsViewController(viewController) else {
+                    guard transitionCoordinator == nil else {
+                        return
+                    }
+                    super.selectedViewController = newValue
+                    return
             }
-            super.selectedIndex = newValue
+
+            selectViewController(viewController)
         }
     }
 
@@ -99,14 +135,120 @@ open class SwipeableTabBarController: UITabBarController {
         panGestureRecognizer = panGesture
     }
 
+    private func selectIndex(_ index: Int) {
+        guard transitionCoordinator == nil else {
+            queueSelectedIndex(index)
+            return
+        }
+
+        super.selectedIndex = index
+    }
+
+    private func selectViewController(_ viewController: UIViewController) {
+        guard transitionCoordinator == nil else {
+            queueSelection(.viewController(viewController, .tap))
+            return
+        }
+
+        super.selectedViewController = viewController
+    }
+
+    private func containsViewController(_ viewController: UIViewController) -> Bool {
+        return viewControllers?.contains { $0 === viewController } == true
+    }
+
+    private func queueSelectedIndex(_ index: Int, source: SelectionSource = .tap) {
+        queueSelection(.index(index, source))
+    }
+
+    private func queueSelection(_ selection: PendingSelection) {
+        pendingSelection = selection
+        schedulePendingSelectionHandler()
+        [swipeAnimatedTransitioning, tapAnimatedTransitioning].forEach { $0?.forceTransitionToFinish() }
+    }
+
+    private func schedulePendingSelectionHandler() {
+        guard !isPendingSelectionHandlerScheduled else {
+            return
+        }
+
+        isPendingSelectionHandlerScheduled = true
+
+        guard let coordinator = transitionCoordinator else {
+            DispatchQueue.main.async { [weak self] in
+                self?.completePendingSelection()
+            }
+            return
+        }
+
+        let didScheduleCompletion = coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.completePendingSelection()
+            }
+        }
+
+        guard didScheduleCompletion else {
+            DispatchQueue.main.async { [weak self] in
+                self?.completePendingSelection()
+            }
+            return
+        }
+    }
+
+    private func completePendingSelection() {
+        isPendingSelectionHandlerScheduled = false
+        applyPendingSelectionIfNeeded()
+    }
+
+    private func applyPendingSelectionIfNeeded() {
+        guard let selection = pendingSelection else {
+            return
+        }
+
+        pendingSelection = nil
+
+        switch selection {
+        case .index(let nextSelectedIndex, let source):
+            guard nextSelectedIndex != super.selectedIndex else {
+                return
+            }
+            preparePendingTransition(from: source)
+            selectIndex(nextSelectedIndex)
+        case .viewController(let viewController, let source):
+            guard super.selectedViewController !== viewController,
+                containsViewController(viewController) else {
+                    return
+            }
+            preparePendingTransition(from: source)
+            selectViewController(viewController)
+        }
+    }
+
+    private func preparePendingTransition(from source: SelectionSource) {
+        shouldUsePanInteractorForCurrentTransition = false
+
+        switch source {
+        case .swipe:
+            currentAnimatedTransitioningType = swipeAnimatedTransitioning
+        case .tap:
+            currentAnimatedTransitioningType = tapAnimatedTransitioning
+        }
+    }
+
     @IBAction func panGestureRecognizerDidPan(_ sender: UIPanGestureRecognizer) {
         if sender.state == .ended || sender.state == .cancelled {
             currentAnimatedTransitioningType = tapAnimatedTransitioning
+            isSwipeGestureDrivingTransition = false
+            shouldUsePanInteractorForCurrentTransition = false
         }
         
         if sender.state == .began || sender.state == .changed {
             // Do not attempt to begin an interactive transition if one is already happening
             guard transitionCoordinator == nil else {
+                if !isSwipeGestureDrivingTransition,
+                    let nextSelectedIndex = selectedIndex(for: sender.translation(in: view)) {
+                    queueSelectedIndex(nextSelectedIndex, source: .swipe)
+                }
                 return
             }
             currentAnimatedTransitioningType = swipeAnimatedTransitioning
@@ -120,21 +262,11 @@ open class SwipeableTabBarController: UITabBarController {
     /// - Parameter sender: gesture recognizer
     private func beginInteractiveTransitionIfPossible(_ sender: UIPanGestureRecognizer) {
         let translation = sender.translation(in: view)
-        
-        if translation.x > 0.0 && selectedIndex > 0 {
-            // Panning right, transition to the left view controller.
-            selectedIndex -= 1
-        } else if translation.x < 0.0 && selectedIndex + 1 < viewControllers?.count ?? 0 {
-            // Panning left, transition to the right view controller.
-            selectedIndex += 1
-        } else if isCyclingEnabled && translation.x > 0.0 && selectedIndex == 0 {
-            // Panning right at first view controller, transition to the last view controller.
-            if let count = viewControllers?.count, count >= 2 {
-                selectedIndex = count - 1
-            }
-        } else if isCyclingEnabled && translation.x < 0.0 && selectedIndex + 1 == viewControllers?.count ?? 0 {
-            // Panning left at last view controller, transition to the first view controller
-            selectedIndex = 0
+
+        if let nextSelectedIndex = selectedIndex(for: translation) {
+            isSwipeGestureDrivingTransition = true
+            shouldUsePanInteractorForCurrentTransition = true
+            selectedIndex = nextSelectedIndex
         } else {
             // Don't reset the gesture recognizer if we skipped starting the
             // transition because we don't have a translation yet (and thus, could
@@ -147,11 +279,38 @@ open class SwipeableTabBarController: UITabBarController {
             }
         }
         
-        transitionCoordinator?.animate(alongsideTransition: nil) { [unowned self] context in
+        guard let coordinator = transitionCoordinator else {
+            shouldUsePanInteractorForCurrentTransition = false
+            isSwipeGestureDrivingTransition = false
+            return
+        }
+
+        coordinator.animate(alongsideTransition: nil) { [unowned self] context in
+            self.shouldUsePanInteractorForCurrentTransition = false
             if context.isCancelled && sender.state == .changed {
                 self.beginInteractiveTransitionIfPossible(sender)
             }
         }
+    }
+
+    private func selectedIndex(for translation: CGPoint) -> Int? {
+        if translation.x > 0.0 && selectedIndex > 0 {
+            // Panning right, transition to the left view controller.
+            return selectedIndex - 1
+        } else if translation.x < 0.0 && selectedIndex + 1 < viewControllers?.count ?? 0 {
+            // Panning left, transition to the right view controller.
+            return selectedIndex + 1
+        } else if isCyclingEnabled && translation.x > 0.0 && selectedIndex == 0 {
+            // Panning right at first view controller, transition to the last view controller.
+            if let count = viewControllers?.count, count >= 2 {
+                return count - 1
+            }
+        } else if isCyclingEnabled && translation.x < 0.0 && selectedIndex + 1 == viewControllers?.count ?? 0 {
+            // Panning left at last view controller, transition to the first view controller
+            return 0
+        }
+
+        return nil
     }
 }
 
@@ -202,7 +361,7 @@ extension SwipeableTabBarController: UITabBarControllerDelegate {
 
     open func tabBarController(_ tabBarController: UITabBarController, interactionControllerFor animationController: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         guard let panGesture = panGestureRecognizer else { return nil }
-        if panGesture.state == .began || panGesture.state == .changed {
+        if shouldUsePanInteractorForCurrentTransition && (panGesture.state == .began || panGesture.state == .changed) {
             return SwipeInteractor(gestureRecognizer: panGesture, edge: currentAnimatedTransitioningType?.targetEdge ?? .right)
         } else {
             return nil
@@ -210,6 +369,13 @@ extension SwipeableTabBarController: UITabBarControllerDelegate {
     }
     
     open func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
-        return transitionCoordinator == nil
+        guard transitionCoordinator == nil else {
+            if let index = tabBarController.viewControllers?.firstIndex(of: viewController) {
+                queueSelectedIndex(index, source: .tap)
+            }
+            return false
+        }
+
+        return true
     }
 }

--- a/SwipeableTabBarController/SwipeableTabBarController.swift
+++ b/SwipeableTabBarController/SwipeableTabBarController.swift
@@ -48,6 +48,9 @@ open class SwipeableTabBarController: UITabBarController {
 
     /// Indicates that UIKit should wire the next transition to the pan interactor.
     private var shouldUsePanInteractorForCurrentTransition = false
+
+    /// True while a programmatic selection setter has already prepared its transition source.
+    private var isApplyingPreparedSelection = false
     
     /// Pan gesture for the swiping interaction
     //swiftlint:disable next implicitly_unwrapped_optional
@@ -135,21 +138,27 @@ open class SwipeableTabBarController: UITabBarController {
         panGestureRecognizer = panGesture
     }
 
-    private func selectIndex(_ index: Int) {
+    private func selectIndex(_ index: Int, source: SelectionSource = .tap, usesPanInteractor: Bool = false) {
         guard transitionCoordinator == nil else {
-            queueSelectedIndex(index)
+            queueSelectedIndex(index, source: source)
             return
         }
 
+        prepareTransition(from: source, usesPanInteractor: usesPanInteractor)
+        isApplyingPreparedSelection = true
+        defer { isApplyingPreparedSelection = false }
         super.selectedIndex = index
     }
 
-    private func selectViewController(_ viewController: UIViewController) {
+    private func selectViewController(_ viewController: UIViewController, source: SelectionSource = .tap) {
         guard transitionCoordinator == nil else {
-            queueSelection(.viewController(viewController, .tap))
+            queueSelection(.viewController(viewController, source))
             return
         }
 
+        prepareTransition(from: source, usesPanInteractor: false)
+        isApplyingPreparedSelection = true
+        defer { isApplyingPreparedSelection = false }
         super.selectedViewController = viewController
     }
 
@@ -164,7 +173,21 @@ open class SwipeableTabBarController: UITabBarController {
     private func queueSelection(_ selection: PendingSelection) {
         pendingSelection = selection
         schedulePendingSelectionHandler()
+
+        guard !selectionMatchesCurrentState(selection) else {
+            return
+        }
+
         [swipeAnimatedTransitioning, tapAnimatedTransitioning].forEach { $0?.forceTransitionToFinish() }
+    }
+
+    private func selectionMatchesCurrentState(_ selection: PendingSelection) -> Bool {
+        switch selection {
+        case .index(let index, _):
+            return index == super.selectedIndex
+        case .viewController(let viewController, _):
+            return super.selectedViewController === viewController
+        }
     }
 
     private func schedulePendingSelectionHandler() {
@@ -212,20 +235,18 @@ open class SwipeableTabBarController: UITabBarController {
             guard nextSelectedIndex != super.selectedIndex else {
                 return
             }
-            preparePendingTransition(from: source)
-            selectIndex(nextSelectedIndex)
+            selectIndex(nextSelectedIndex, source: source, usesPanInteractor: false)
         case .viewController(let viewController, let source):
             guard super.selectedViewController !== viewController,
                 containsViewController(viewController) else {
                     return
             }
-            preparePendingTransition(from: source)
-            selectViewController(viewController)
+            selectViewController(viewController, source: source)
         }
     }
 
-    private func preparePendingTransition(from source: SelectionSource) {
-        shouldUsePanInteractorForCurrentTransition = false
+    private func prepareTransition(from source: SelectionSource, usesPanInteractor: Bool) {
+        shouldUsePanInteractorForCurrentTransition = usesPanInteractor
 
         switch source {
         case .swipe:
@@ -265,8 +286,7 @@ open class SwipeableTabBarController: UITabBarController {
 
         if let nextSelectedIndex = selectedIndex(for: translation) {
             isSwipeGestureDrivingTransition = true
-            shouldUsePanInteractorForCurrentTransition = true
-            selectedIndex = nextSelectedIndex
+            selectIndex(nextSelectedIndex, source: .swipe, usesPanInteractor: true)
         } else {
             // Don't reset the gesture recognizer if we skipped starting the
             // transition because we don't have a translation yet (and thus, could
@@ -376,6 +396,9 @@ extension SwipeableTabBarController: UITabBarControllerDelegate {
             return false
         }
 
+        if !isApplyingPreparedSelection {
+            prepareTransition(from: .tap, usesPanInteractor: false)
+        }
         return true
     }
 }


### PR DESCRIPTION
## Summary
Fixes #52 by queuing tab selection changes while UIKit is still completing the current transition. The latest requested tab is applied after the active transition finishes, which avoids overlapping transitions from rapid swipes, tab taps, or programmatic selection changes.

This also adds example stress modes and UI coverage for rapid `selectedIndex` / `selectedViewController` changes.

## Validation
- `git diff --check`
- `xcodebuild test` passed in fork CI on macOS 15: https://github.com/apples-kksk/SwipeableTabBarController/actions/runs/25959356486

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#52: Very quick swipes cause app to freeze](https://oss.issuehunt.io/repos/80658654/issues/52)
---
</details>
<!-- /Issuehunt content-->

